### PR TITLE
Fixing thread affinity in AHC callbacks

### DIFF
--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -78,14 +78,14 @@ object AsyncHttpClient {
     new StreamedAsyncHandler[Unit] {
       var state: State = State.CONTINUE
       var response: Response[F] = Response()
-      val dispose = F delay { state = State.ABORT }
+      val dispose = F.delay { state = State.ABORT }
 
       override def onStream(publisher: Publisher[HttpResponseBodyPart]): State = {
         val eff = for {
           subscriber <- StreamSubscriber[F, HttpResponseBodyPart]
 
           subscribeF = F.delay(publisher.subscribe(subscriber))
-          bodyDisposal <- Ref of[F, F[Unit]] {
+          bodyDisposal <- Ref.of[F, F[Unit]] {
             subscribeF >> subscriber.stream.take(0).compile.drain
           }
 

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -3,6 +3,7 @@ package client
 package asynchttpclient
 
 import cats.effect._
+import cats.effect.concurrent._
 import cats.implicits._
 import cats.effect.implicits._
 import fs2.Stream._
@@ -77,25 +78,28 @@ object AsyncHttpClient {
     new StreamedAsyncHandler[Unit] {
       var state: State = State.CONTINUE
       var response: Response[F] = Response()
-      val dispose = F.delay { state = State.ABORT }
+      val dispose = F delay { state = State.ABORT }
 
       override def onStream(publisher: Publisher[HttpResponseBodyPart]): State = {
         // backpressure is handled by requests to the reactive streams subscription
-        StreamSubscriber[F, HttpResponseBodyPart]
-          .map { subscriber =>
-            val body = subscriber.stream.flatMap(part => chunk(Chunk.bytes(part.getBodyPartBytes)))
-            response = response.copy(body = body)
-            // Run this before we return the response, lest we violate
-            // Rule 3.16 of the reactive streams spec.
-            publisher.subscribe(subscriber)
-            // We have a fully formed response now.  Complete the
-            // callback, rather than waiting for onComplete, or else we'll
-            // buffer the entire response before we return it for
-            // streaming consumption.
-            invokeCallback(logger)(cb(Right(response -> dispose)))
+        val eff = for {
+          subscriber <- StreamSubscriber[F, HttpResponseBodyPart]
+
+          subscribeF = F.delay(publisher.subscribe(subscriber))
+          bodyDisposal <- Ref of[F, F[Unit]] {
+            subscribeF >> subscriber.stream.take(0).compile.drain
           }
-          .runAsync(_ => IO.unit)
-          .unsafeRunSync()
+
+          body = Stream.eval(F.uncancelable(bodyDisposal.set(F.unit) >> subscribeF)) >>
+            subscriber.stream.flatMap(part => chunk(Chunk.bytes(part.getBodyPartBytes)))
+
+          responseWithBody = response.copy(body = body)
+
+          _ <- F.delay(cb(Right(responseWithBody -> (dispose >> bodyDisposal.get.flatten))))
+        } yield ()
+
+        eff.runAsync(_ => IO.unit).unsafeRunSync()
+
         state
       }
 
@@ -115,9 +119,9 @@ object AsyncHttpClient {
       override def onThrowable(throwable: Throwable): Unit =
         invokeCallback(logger)(cb(Left(throwable)))
 
-      override def onCompleted(): Unit = {
-        // Don't close here.  onStream may still be being called.
-      }
+      // it's okay to invoke this repeatedly since repeated async callbacks are dropped by law
+      override def onCompleted(): Unit =
+        invokeCallback(logger)(cb(Right(response -> dispose)))
     }
 
   private def toAsyncRequest[F[_]: ConcurrentEffect](request: Request[F]): AsyncRequest = {

--- a/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
+++ b/async-http-client/src/main/scala/org/http4s/client/asynchttpclient/AsyncHttpClient.scala
@@ -81,7 +81,6 @@ object AsyncHttpClient {
       val dispose = F delay { state = State.ABORT }
 
       override def onStream(publisher: Publisher[HttpResponseBodyPart]): State = {
-        // backpressure is handled by requests to the reactive streams subscription
         val eff = for {
           subscriber <- StreamSubscriber[F, HttpResponseBodyPart]
 


### PR DESCRIPTION
Depends on #1 

The easy route here would be to take a `ContextShift`, but we can't do that without breaking binary compatibility. So instead we use the same mechanism that `invokeCallback` does and we spawn a fiber just to get the shift.